### PR TITLE
Add swagger UI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
           name: spec-file
           path: tsp-output/schema/openapi.yaml
 
-      - name: Upload redocly-ui
+      - name: Upload swagger-ui
         uses: actions/upload-artifact@v4
         with:
           name: swagger-ui

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,12 @@ jobs:
           name: spec-file
           path: tsp-output/schema/openapi.yaml
 
+      - name: Upload redocly-ui
+        uses: actions/upload-artifact@v4
+        with:
+          name: swagger-ui
+          path: swagger-ui.html
+
   deploy:
     needs: generate-openapi-spec
     runs-on: ubuntu-latest
@@ -43,20 +49,29 @@ jobs:
         with:
           name: spec-file
 
+      - name: Download swagger-ui.html
+        uses: actions/download-artifact@v4
+        with:
+          name: swagger-ui
+
       - uses: actions/setup-node@v3
 
       - name: Install dependencies
         run: |
           npm i -g @redocly/cli@latest
 
-      - name: Generate Swagger UI
+      - name: Generate Redocly and Swagger UI
         run: |
           mkdir -p ./redocly-ui
-          cp openapi.yaml ./redocly-ui/
-          redocly build-docs openapi.yaml --output ./redocly-ui/index.html
+          redocly build-docs openapi.yaml --output ./redocly-ui/redocly.html
+
+          mkdir -p ./publish
+          cp openapi.yaml ./publish/
+          cp redocly-ui/redocly.html ./publish/
+          cp swagger-ui.html ./publish/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./redocly-ui
+          publish_dir: ./publish

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,8 @@ name: Deploy GitHub Pages
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   generate-openapi-spec:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,6 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   generate-openapi-spec:
@@ -53,10 +51,12 @@ jobs:
 
       - name: Generate Swagger UI
         run: |
-          redocly build-docs openapi.yaml --output ./swagger-ui/index.html
+          mkdir -p ./redocly-ui
+          cp openapi.yaml ./redocly-ui/
+          redocly build-docs openapi.yaml --output ./redocly-ui/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./swagger-ui
+          publish_dir: ./redocly-ui

--- a/main.tsp
+++ b/main.tsp
@@ -12,6 +12,14 @@ scalar uuid extends string;
 @format("email")
 scalar email extends string;
 
+model User {
+  id: uuid;
+  name: string;
+  email: email;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+}
+
 model PaginatedParams {
   @example(1)
   @query
@@ -66,6 +74,17 @@ namespace BasicController {
     refreshToken: string;
   }
 
+  model RegisterRequest {
+    @example("username")
+    username: string;
+
+    @example("password")
+    password: string;
+
+    @example("email@example.com")
+    email: email;
+  }
+
   @route("/login")
   @post
   op login(@body body: LoginRequest): {
@@ -80,6 +99,16 @@ namespace BasicController {
   @post
   op logout(): {
     @statusCode status: 204;
+  };
+
+  @route("/register")
+  @post
+  op register(@body body: RegisterRequest): {
+    @statusCode status: 200;
+    @body body: User;
+  } | {
+    @statusCode status: 400;
+    @body body: ProblemDetails;
   };
 }
 
@@ -100,14 +129,6 @@ namespace UserController {
     @maxLength(20)
     @pattern("^[a-zA-Z0-9]+$")
     password: string;
-  }
-
-  model User {
-    id: uuid;
-    name: string;
-    email: email;
-    createdAt: utcDateTime;
-    updatedAt: utcDateTime;
   }
 
   @get op list(...PaginatedParams): {

--- a/main.tsp
+++ b/main.tsp
@@ -236,8 +236,17 @@ namespace ScoreboardController {
 
   @route("/{id}/items")
   namespace ScoreboardItems {
-    /** Create a scoreboard item */
     @tag("Scoreboard Items")
+    @get
+    op listScoreboardItems(@path id: uuid, ...PaginatedParams): {
+      @statusCode status: 200;
+      @body body: PaginatedResponse<ScoreboardItem>;
+    } | {
+      @statusCode status: 500;
+      @body body: ProblemDetails;
+    };
+    
+    /** Create a scoreboard item */
     @tag("Scoreboard Items")
     @post
     op createScoreboardItem(

--- a/main.tsp
+++ b/main.tsp
@@ -14,7 +14,7 @@ scalar email extends string;
 
 model User {
   id: uuid;
-  name: string;
+  username: string;
   email: email;
   createdAt: utcDateTime;
   updatedAt: utcDateTime;
@@ -120,14 +120,15 @@ namespace UserController {
     @example("John Doe")
     @minLength(1)
     @maxLength(20)
-    name: string;
+    @pattern("^\\w+$")
+    @doc("Username must be at least 1 character long and contain only letters, numbers, and underscores.")
+    username: string;
 
     email: email;
 
     @example("password")
     @minLength(8)
     @maxLength(20)
-    @pattern("^[a-zA-Z0-9]+$")
     password: string;
   }
 

--- a/main.tsp
+++ b/main.tsp
@@ -85,6 +85,15 @@ namespace BasicController {
     email: email;
   }
 
+  @route("/me")
+  @get op me(): {
+    @statusCode status: 200;
+    @body body: User;
+  } | {
+    @statusCode status: 401;
+    @body body: ProblemDetails;
+  };
+
   @route("/login")
   @post
   op login(@body body: LoginRequest): {

--- a/main.tsp
+++ b/main.tsp
@@ -86,7 +86,8 @@ namespace BasicController {
   }
 
   @route("/me")
-  @get op me(): {
+  @get
+  op me(): {
     @statusCode status: 200;
     @body body: User;
   } | {

--- a/main.tsp
+++ b/main.tsp
@@ -245,7 +245,7 @@ namespace ScoreboardController {
       @statusCode status: 500;
       @body body: ProblemDetails;
     };
-    
+
     /** Create a scoreboard item */
     @tag("Scoreboard Items")
     @post

--- a/swagger-ui.html
+++ b/swagger-ui.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="SwaggerUI" />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+  window.onload = () => {
+    window.ui = SwaggerUIBundle({
+      url: 'https://nycu-sdc.github.io/scoreboard-practice-api/openapi.yaml',
+      dom_id: '#swagger-ui',
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Type of change
CI

## Purpose
Support deploying both Swagger UI and Redocly for API documentation on GitHub Pages.

## Additional information
- Updated workflow to upload and download a custom `swagger-ui.html` file.
- Changed `publish_dir` to `./publish` to include openapi.yaml, Redocly, and Swagger UI outputs.
- Introduced User and RegisterRequest models, and added a /register endpoint.
- Replaced `name` with `username` in `UserController`, adding format constraints and docs.
- Added paginated `GET /scoreboards/{id}/items` endpoint.
- Added `swagger-ui.html` static file using Swagger CDN with link to published `openapi.yaml`.